### PR TITLE
Added flake8 F401 ignore rule for __init__.py files

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,3 +3,4 @@ max-line-length = 119
 extend-ignore = W503, E203, E701
 exclude = .git, .github, build, dist, docs, venv, .venv, env, .env, .idea, .vscode
 max-complexity = 10
+per-file-ignores = __init__.py:F401


### PR DESCRIPTION
**Description:**
Added flake8 F401 ignore rule for __init__.py files

**Checklist:**
Please be sure to check all boxes honestly. This is to ensure a smooth development process, and to reduce the 
likelihood of needing to make additional changes later on.
- [X] I understand that changes authored by individuals who have not signed a Contributor License Agreement (CLA), 
or whose authorship we cannot verify, may not be accepted.
- [X] These contribution address a triaged issue.
- [X] I have performed a self-review of my code and my changes generate no new warnings.
- [X] I have included unit tests for my code contributions, and all tests are passing.
- [X] The docstrings are complete, include doctests demonstrating usage, and are properly formatted. 
I have verified that any updates to the project documentation are complete and look okay.
- [X] I have confirmed all my code contributions are formatted in accordance with the project's Flake8, Black, 
and isort style configurations.
- [X] No unnecessary changes have been made to the Poetry lock file, but `pyproject.toml` and the Poetry lock file 
have been updated to reflect any dependency changes.
- [X] I acknowledge that upon the submission of this pull request, Qoherent will assume the copyright for this 
contribution.

<!-- A heartfelt thank you from everyone at Qoherent and the broader radio community for taking the time to 
contribute to RIA Core. 🙏💖 -->
