### PR TITLE
Workflow fail if black and isort fail

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -38,8 +38,7 @@ jobs:
           with:
             options: "--check --verbose"
             src: "./"
-            use_pyproject: true
-            version: "~= 24.4"
+            # use_pyproject: true, should be used but causing issues so commenting for now
 
         - name: Run Isort
           run: isort .

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -33,8 +33,18 @@ jobs:
         - name: Run Black
           run: black ./ --config pyproject.toml
 
+        - name: Check Black formatting
+          uses: psf/black@stable
+          with:
+            options: "--check --verbose"
+            src: "./"
+            use_pyproject: true
+
         - name: Run Isort
           run: isort .
+
+        - name: Check Isort formatting
+          uses: isort/isort-action@master
 
         - name: Setup flake8 annotations
           uses: rbialon/flake8-annotations@v1.1

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -19,7 +19,7 @@ jobs:
         - name: Set up Python environment
           uses: actions/setup-python@v5
           with:
-            python-version: "3.10"
+            python-version: "3.11"
 
         - name: Install dependencies
           run: |

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -27,21 +27,12 @@ jobs:
             pip install poetry
             poetry lock --no-update
             poetry install
-            pip install black
-            pip install isort
-
-        - name: Run Black
-          run: black ./ --config pyproject.toml
 
         - name: Check Black formatting
           uses: psf/black@stable
           with:
             options: "--check --verbose"
             src: "./"
-            # use_pyproject: true, should be used but causing issues so commenting for now
-
-        - name: Run Isort
-          run: isort .
 
         - name: Check Isort formatting
           uses: isort/isort-action@master

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -39,6 +39,7 @@ jobs:
             options: "--check --verbose"
             src: "./"
             use_pyproject: true
+            version: "~= 24.4"
 
         - name: Run Isort
           run: isort .


### PR DESCRIPTION
**Description:**
Ensure that the workflow fails when black and isort style guides are not met. 


**Related Issues:**
#36 

**Tips for the Reviewer:**
Push black and isort breaking changes to observe workflow. 

Note: I was unsure if black and isort should still run as they did before, kept them as is for now however, that can be removed as needed. 

**Checklist:**
Please be sure to check all boxes honestly. This is to ensure a smooth development process, and to reduce the 
likelihood of needing to make additional changes later on.
- [X] I understand that changes authored by individuals who have not signed a Contributor License Agreement (CLA), 
or whose authorship we cannot verify, may not be accepted.
- [X] These contribution address a triaged issue.
- [X] I have performed a self-review of my code and my changes generate no new warnings.
- [X] I have included unit tests for my code contributions, and all tests are passing.
- [X] The docstrings are complete, include doctests demonstrating usage, and are properly formatted. 
I have verified that any updates to the project documentation are complete and look okay.
- [X] I have confirmed all my code contributions are formatted in accordance with the project's Flake8, Black, 
and isort style configurations.
- [X] No unnecessary changes have been made to the Poetry lock file, but `pyproject.toml` and the Poetry lock file 
have been updated to reflect any dependency changes.
- [X] I acknowledge that upon the submission of this pull request, Qoherent will assume the copyright for this 
contribution.

<!-- A heartfelt thank you from everyone at Qoherent and the broader radio community for taking the time to 
contribute to RIA Core. 🙏💖 -->
